### PR TITLE
fix: correct workout days count in Progress page

### DIFF
--- a/src/client/routes/Progress/Progress.tsx
+++ b/src/client/routes/Progress/Progress.tsx
@@ -1511,8 +1511,9 @@ function DailySummaries({ dateRange }: { dateRange: DateRange }) {
     );
 }
 
-function StatsOverview() {
-    const { data, isLoading } = useActivitySummary({ period: 'week' });
+function StatsOverview({ dateRange }: { dateRange: DateRange }) {
+    const { startDate, endDate } = useMemo(() => getDateRange(dateRange), [dateRange]);
+    const { data, isLoading } = useActivitySummary({ period: 'day', startDate, endDate });
 
     const totalSets = data?.totalSets ?? 0;
     const totalDays = data?.totalWorkoutDays ?? 0;
@@ -1798,7 +1799,7 @@ export function Progress() {
                 </div>
             </div>
 
-            <StatsOverview />
+            <StatsOverview dateRange={dateRange} />
 
             <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as ProgressTab)}>
                 <TabsList className="w-full mb-4">


### PR DESCRIPTION
StatsOverview was using period: 'week' which grouped workout days by
week instead of counting individual days. Changed to period: 'day'
with proper date range, so days in the same week are now counted
separately.