### PR TITLE
fix: use bg-card for selection bar overlay background

### DIFF
--- a/src/client/routes/Home/Home.tsx
+++ b/src/client/routes/Home/Home.tsx
@@ -43,6 +43,7 @@ import {
     useStartSession,
     useSetPlanWorkoutId,
     useSetPlanWorkoutName,
+    useIsSessionActive,
 } from '@/client/features/workout';
 import type { WorkoutTab } from '@/client/features/workout';
 import type { ExerciseWeekProgress } from '@/apis/weekly-progress/types';
@@ -85,6 +86,7 @@ export function Home() {
     const startSession = useStartSession();
     const setPlanWorkoutId = useSetPlanWorkoutId();
     const setPlanWorkoutName = useSetPlanWorkoutName();
+    const isWorkoutActive = useIsSessionActive();
 
     // Plan workouts data (scoped to active plan)
     const { data: planWorkoutsData, isLoading: planWorkoutsLoading } = usePlanWorkouts(activePlanId);
@@ -486,8 +488,13 @@ export function Home() {
                         style={{
                             // On mobile, position above the BottomNavBar which includes safe-area-inset-bottom
                             // BottomNavBar height: pt-1 (4px) + h-14 (56px) + paddingBottom (safe-area + 4px) = 64px + safe-area
-                            // On desktop (≥640px), bottom nav is hidden, so use bottom: 0
-                            bottom: isMobile ? 'calc(64px + env(safe-area-inset-bottom, 0px))' : 0,
+                            // When FloatingWorkoutBar is active, add ~70px more to avoid overlap
+                            // On desktop (≥640px), bottom nav is hidden, so use bottom: 0 (or 70px if workout active)
+                            bottom: isMobile
+                                ? isWorkoutActive
+                                    ? 'calc(134px + env(safe-area-inset-bottom, 0px))'
+                                    : 'calc(64px + env(safe-area-inset-bottom, 0px))'
+                                : isWorkoutActive ? '70px' : 0,
                         }}
                     >
                         <div className="flex items-center gap-3 max-w-lg mx-auto">

--- a/src/client/routes/Progress/Progress.tsx
+++ b/src/client/routes/Progress/Progress.tsx
@@ -58,6 +58,7 @@ import type { ActivityLogEntry, DailySummary } from '@/apis/activity-logs/types'
 import { listPlanExercises } from '@/apis/plan-exercises/client';
 import { usePlans } from '@/client/features/workout/hooks';
 import { useActivePlanId } from '@/client/features/workout/store';
+import { useIsSessionActive } from '@/client/features/workout';
 import { useQueryDefaults } from '@/client/query/defaults';
 import {
     BarChart,
@@ -1031,9 +1032,13 @@ function SelectionActionBar({
 }) {
     const isSingleSelection = selectedCount === 1;
     const isAnyLoading = isDeleting || isDuplicating || isEditing;
+    // Move up when FloatingWorkoutBar is visible to avoid overlap
+    const isWorkoutActive = useIsSessionActive();
 
     return (
-        <div className="fixed bottom-20 left-4 right-4 bg-card border border-border rounded-xl shadow-lg p-2 z-50">
+        <div className={`fixed left-4 right-4 bg-card border border-border rounded-xl shadow-lg p-2 z-50 ${
+            isWorkoutActive ? 'bottom-[150px]' : 'bottom-20'
+        }`}>
             <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                     <Button


### PR DESCRIPTION
Changed from bg-background/95 to bg-card/95 to provide visual contrast
between the overlay panel and the main page background.