### PR TITLE
fix: fallback to exercise weekly sets for legacy workout items

### DIFF
--- a/src/client/routes/Home/components/PlanWorkoutCard.tsx
+++ b/src/client/routes/Home/components/PlanWorkoutCard.tsx
@@ -59,7 +59,7 @@ export function PlanWorkoutCard({
 
             return {
                 ...ex,
-                workoutTargetSets: item.sets,  // Sets allocated to this workout
+                workoutTargetSets: item.sets ?? ex.targetSets,  // Sets allocated to this workout (fallback to weekly target for legacy data)
                 workoutSetsCompleted: workoutProgress?.setsCompleted || 0,  // Sets completed in this workout
             };
         })

--- a/src/client/routes/ManagePlan/components/workouts/WorkoutDialog.tsx
+++ b/src/client/routes/ManagePlan/components/workouts/WorkoutDialog.tsx
@@ -45,13 +45,16 @@ export function WorkoutDialog({
             if (editingWorkout && workout._id === editingWorkout._id) continue;
 
             for (const item of workout.items) {
+                // Fallback to exercise's weekly sets for legacy data without per-workout allocation
+                const exercise = planExercises.find(pe => pe._id === item.planExerciseId);
+                const sets = item.sets ?? exercise?.sets ?? 0;
                 const current = allocations.get(item.planExerciseId) || 0;
-                allocations.set(item.planExerciseId, current + item.sets);
+                allocations.set(item.planExerciseId, current + sets);
             }
         }
 
         return allocations;
-    }, [planWorkouts, editingWorkout]);
+    }, [planWorkouts, editingWorkout, planExercises]);
 
     // Reset form when dialog opens or editingWorkout changes
     useEffect(() => {
@@ -62,8 +65,10 @@ export function WorkoutDialog({
                 const exerciseMap = new Map<string, number>();
                 for (const item of editingWorkout.items) {
                     // Only include IDs that still exist in planExercises
-                    if (planExercises.some(pe => pe._id === item.planExerciseId)) {
-                        exerciseMap.set(item.planExerciseId, item.sets);
+                    const exercise = planExercises.find(pe => pe._id === item.planExerciseId);
+                    if (exercise) {
+                        // Fallback to exercise's weekly sets for legacy data without per-workout allocation
+                        exerciseMap.set(item.planExerciseId, item.sets ?? exercise.sets);
                     }
                 }
                 setSelectedExercises(exerciseMap);

--- a/src/client/routes/ManagePlan/components/workouts/WorkoutsTab.tsx
+++ b/src/client/routes/ManagePlan/components/workouts/WorkoutsTab.tsx
@@ -144,11 +144,15 @@ export function WorkoutsTab({
             {
                 planId,
                 name: `${workout.name} (Copy)`,
-                items: workout.items.map((item, index) => ({
-                    planExerciseId: item.planExerciseId,
-                    order: index,
-                    sets: item.sets,
-                })),
+                items: workout.items.map((item, index) => {
+                    // Fallback to exercise's weekly sets for legacy data without per-workout allocation
+                    const exercise = planExercises.find(pe => pe._id === item.planExerciseId);
+                    return {
+                        planExerciseId: item.planExerciseId,
+                        order: index,
+                        sets: item.sets ?? exercise?.sets ?? 0,
+                    };
+                }),
             },
             {
                 onSuccess: () => {


### PR DESCRIPTION
The multi-workout exercise allocation feature added a `sets` field to
workout items, but existing data doesn't have this field. This caused
all workouts to display "0/0 sets" because `item.sets` was undefined.

Fixed by adding fallback to exercise's weekly `targetSets` when
`item.sets` is undefined:
- PlanWorkoutCard.tsx: Display workout exercise progress
- WorkoutDialog.tsx: Allocation calculation and edit form population
- WorkoutsTab.tsx: Duplicate workout function