### PR TITLE
fix: use || instead of ?? for sets fallback (handles explicit 0)

### DIFF
--- a/src/client/routes/Home/components/PlanWorkoutCard.tsx
+++ b/src/client/routes/Home/components/PlanWorkoutCard.tsx
@@ -59,7 +59,7 @@ export function PlanWorkoutCard({
 
             return {
                 ...ex,
-                workoutTargetSets: item.sets ?? ex.targetSets,  // Sets allocated to this workout (fallback to weekly target for legacy data)
+                workoutTargetSets: item.sets || ex.targetSets,  // Sets allocated to this workout (fallback to weekly target when 0 or undefined)
                 workoutSetsCompleted: workoutProgress?.setsCompleted || 0,  // Sets completed in this workout
             };
         })

--- a/src/client/routes/ManagePlan/components/workouts/WorkoutDialog.tsx
+++ b/src/client/routes/ManagePlan/components/workouts/WorkoutDialog.tsx
@@ -47,7 +47,7 @@ export function WorkoutDialog({
             for (const item of workout.items) {
                 // Fallback to exercise's weekly sets for legacy data without per-workout allocation
                 const exercise = planExercises.find(pe => pe._id === item.planExerciseId);
-                const sets = item.sets ?? exercise?.sets ?? 0;
+                const sets = item.sets || exercise?.sets || 0;
                 const current = allocations.get(item.planExerciseId) || 0;
                 allocations.set(item.planExerciseId, current + sets);
             }
@@ -68,7 +68,7 @@ export function WorkoutDialog({
                     const exercise = planExercises.find(pe => pe._id === item.planExerciseId);
                     if (exercise) {
                         // Fallback to exercise's weekly sets for legacy data without per-workout allocation
-                        exerciseMap.set(item.planExerciseId, item.sets ?? exercise.sets);
+                        exerciseMap.set(item.planExerciseId, item.sets || exercise.sets);
                     }
                 }
                 setSelectedExercises(exerciseMap);

--- a/src/client/routes/ManagePlan/components/workouts/WorkoutsTab.tsx
+++ b/src/client/routes/ManagePlan/components/workouts/WorkoutsTab.tsx
@@ -150,7 +150,7 @@ export function WorkoutsTab({
                     return {
                         planExerciseId: item.planExerciseId,
                         order: index,
-                        sets: item.sets ?? exercise?.sets ?? 0,
+                        sets: item.sets || exercise?.sets || 0,
                     };
                 }),
             },


### PR DESCRIPTION
## Summary
- Fixes workout sets still showing 0/0 for legacy data
- The server handlers default `sets` to `0` for legacy workout items, so `item.sets ?? fallback` returns `0` (not the fallback)
- Changed to `||` so that `0 || fallback` correctly falls back to the exercise's weekly target sets

## Test plan
- [ ] Verify existing workouts (without per-workout set allocation) display the correct exercise sets
- [ ] Verify new workouts with explicit set allocation still work correctly