### PR TITLE
feat: add multi-workout exercise allocation (v2)

### DIFF
--- a/docs/plan-workouts.md
+++ b/docs/plan-workouts.md
@@ -27,14 +27,15 @@ interface PlanWorkout {
 interface PlanWorkoutItem {
     planExerciseId: ObjectId;   // Reference to plan exercise
     order: number;              // Order within the workout
+    sets?: number;              // Per-workout set allocation (optional)
 }
 ```
 
 ### Key Design Decisions
 
-1. **No `exerciseDefId` storage**: Workouts reference `planExerciseId` directly, which already contains the exercise definition reference. This ensures workouts stay in sync with plan exercise configuration (sets, reps, weight).
+1. **No `exerciseDefId` storage**: Workouts reference `planExerciseId` directly, which already contains the exercise definition reference. This ensures workouts stay in sync with plan exercise configuration (reps, weight).
 
-2. **No per-workout overrides**: Exercises use the plan's configured values. Future versions may add per-workout overrides.
+2. **Per-workout set allocation**: Each workout item can optionally specify `sets` to override the exercise's weekly sets. This allows splitting an exercise across multiple workouts (see [Multi-Workout Set Allocation](#multi-workout-set-allocation)).
 
 3. **Cascade deletion**: When a plan is deleted, all its workouts should also be deleted.
 
@@ -97,8 +98,8 @@ createMutation.mutate({
     planId,
     name: 'Push Day',
     items: [
-        { planExerciseId: 'abc123', order: 0 },
-        { planExerciseId: 'def456', order: 1 },
+        { planExerciseId: 'abc123', order: 0, sets: 5 },  // Custom set allocation
+        { planExerciseId: 'def456', order: 1 },          // Uses exercise's weekly sets
     ],
 });
 ```
@@ -121,6 +122,54 @@ When starting an active workout session:
 
 ### Always Syncs to Weekly Progress
 Set +/- operations always sync to the backend weekly progress. The `sessionSource` concept was removed since an active plan is always required.
+
+## Multi-Workout Set Allocation
+
+Exercises can be split across multiple workouts with custom set counts per workout.
+
+### Use Case
+
+An exercise with 10 weekly sets can be split into:
+- **Workout A (Push)**: 5 sets
+- **Workout B (Full Body)**: 5 sets
+
+The Exercise Tab shows total progress (e.g., 7/10), while each workout shows its own progress (e.g., 5/5 and 2/5).
+
+### Data Structure
+
+Progress is tracked at two levels:
+
+```typescript
+// In PlanData (plan-data store)
+interface PlanData {
+    // Total weekly progress per exercise
+    weekProgress: Record<number, Record<string, ExerciseProgress>>;
+    // Workout-specific sets: {weekNumber: {workoutId: {exerciseId: setsCompleted}}}
+    workoutSets: Record<number, Record<string, Record<string, number>>>;
+}
+```
+
+### Auto-Fill Logic
+
+When adding/removing sets from the **Exercise Tab** or **ad-hoc workouts**, sets are automatically assigned to workouts without prompting the user:
+
+| Action | Strategy | Example |
+|--------|----------|---------|
+| **Add set** | Fill first workout with capacity | If Workout A is 5/5 and B is 2/5, new set goes to B |
+| **Remove set** | Remove from last workout with sets | If A has 5/5 and B has 2/5, removal comes from B |
+| **Complete all** | Same as Add set (repeated) | Fills A to 5/5, then B to 5/5 |
+
+This FIFO/LIFO approach ensures predictable behavior without user intervention.
+
+### When Starting a Saved Workout
+
+Sets are tracked against that specific workout. The workout card shows workout-specific progress (e.g., "3/5 sets") not total progress.
+
+### Implementation Details
+
+See inline comments in:
+- `src/client/routes/Home/Home.tsx` - Auto-fill functions (`getFirstWorkoutWithCapacity`, `getLastWorkoutWithSets`)
+- `src/client/features/plan-data/store.ts` - Store actions (`incrementSetForWorkout`, `decrementSetForWorkout`)
 
 ## UI Locations
 

--- a/src/apis/plan-workouts/handlers/createPlanWorkout.ts
+++ b/src/apis/plan-workouts/handlers/createPlanWorkout.ts
@@ -53,6 +53,8 @@ export const createPlanWorkout = async (
             items: request.items.map((item, index) => ({
                 planExerciseId: toDocumentId(item.planExerciseId),
                 order: index,
+                // Include sets only if explicitly provided (undefined means use exercise's weekly sets)
+                ...(item.sets !== undefined && { sets: item.sets }),
             })),
         };
 
@@ -67,6 +69,7 @@ export const createPlanWorkout = async (
             items: newWorkout.items.map((item) => ({
                 planExerciseId: toStringId(item.planExerciseId),
                 order: item.order,
+                ...(item.sets !== undefined && { sets: item.sets }),
             })),
             order: newWorkout.order,
             createdAt: newWorkout.createdAt.toISOString(),

--- a/src/apis/plan-workouts/handlers/listPlanWorkouts.ts
+++ b/src/apis/plan-workouts/handlers/listPlanWorkouts.ts
@@ -32,6 +32,8 @@ export const listPlanWorkouts = async (
             items: workout.items.map((item) => ({
                 planExerciseId: toStringId(item.planExerciseId),
                 order: item.order,
+                // Pass through sets if defined (undefined means use exercise's weekly sets as default)
+                ...(item.sets !== undefined && { sets: item.sets }),
             })),
             order: workout.order,
             createdAt: workout.createdAt.toISOString(),

--- a/src/apis/plan-workouts/handlers/updatePlanWorkout.ts
+++ b/src/apis/plan-workouts/handlers/updatePlanWorkout.ts
@@ -71,7 +71,7 @@ export const updatePlanWorkout = async (
         // Build update object
         const update: {
             name?: string;
-            items?: { planExerciseId: ReturnType<typeof toDocumentId>; order: number }[];
+            items?: { planExerciseId: ReturnType<typeof toDocumentId>; order: number; sets?: number }[];
             updatedAt: Date;
         } = {
             updatedAt: new Date(),
@@ -85,6 +85,8 @@ export const updatePlanWorkout = async (
             update.items = request.items.map((item, index) => ({
                 planExerciseId: toDocumentId(item.planExerciseId),
                 order: index,
+                // Include sets only if explicitly provided (undefined means use exercise's weekly sets)
+                ...(item.sets !== undefined && { sets: item.sets }),
             }));
         }
 
@@ -108,6 +110,7 @@ export const updatePlanWorkout = async (
             items: updatedWorkout.items.map((item) => ({
                 planExerciseId: toStringId(item.planExerciseId),
                 order: item.order,
+                ...(item.sets !== undefined && { sets: item.sets }),
             })),
             order: updatedWorkout.order,
             createdAt: updatedWorkout.createdAt.toISOString(),

--- a/src/apis/plan-workouts/types.ts
+++ b/src/apis/plan-workouts/types.ts
@@ -29,7 +29,7 @@ export interface CreatePlanWorkoutRequest {
     _id?: string; // Client-generated UUID for optimistic updates
     planId: string;
     name: string;
-    items: { planExerciseId: string; order: number }[];
+    items: { planExerciseId: string; order: number; sets?: number }[];
 }
 
 export interface CreatePlanWorkoutResponse {
@@ -45,7 +45,7 @@ export interface UpdatePlanWorkoutRequest {
     planId: string;
     workoutId: string;
     name?: string;
-    items?: { planExerciseId: string; order: number }[];
+    items?: { planExerciseId: string; order: number; sets?: number }[];
 }
 
 export interface UpdatePlanWorkoutResponse {

--- a/src/client/features/plan-data/hooks.ts
+++ b/src/client/features/plan-data/hooks.ts
@@ -483,9 +483,17 @@ export function useClearAllPlanData() {
  *
  * This is the unified way to update set progress across the app.
  *
+ * @param planId - The plan ID
+ * @param weekNumber - The week number
+ * @param workoutId - Optional workout ID for workout-specific tracking
+ *
  * @example
  * ```typescript
+ * // For exercise tab (no workout tracking)
  * const { addSet, removeSet, completeAllSets } = useSetProgress(planId, weekNumber);
+ *
+ * // For workout tab (with workout tracking)
+ * const { addSet, removeSet } = useSetProgress(planId, weekNumber, workoutId);
  *
  * // Add a single set
  * addSet(exerciseId, targetSets);
@@ -497,11 +505,13 @@ export function useClearAllPlanData() {
  * completeAllSets(exerciseId, targetSets, currentSetsCompleted);
  * ```
  */
-export function useSetProgress(planId: string | null, weekNumber: number) {
+export function useSetProgress(planId: string | null, weekNumber: number, workoutId?: string | null) {
     const queryClient = useQueryClient();
     const incrementSet = usePlanDataStore((s) => s.incrementSet);
     const decrementSet = usePlanDataStore((s) => s.decrementSet);
     const completeAllSetsAction = usePlanDataStore((s) => s.completeAllSets);
+    const incrementSetForWorkout = usePlanDataStore((s) => s.incrementSetForWorkout);
+    const decrementSetForWorkout = usePlanDataStore((s) => s.decrementSetForWorkout);
 
     // Activity mutations (internal)
     const addActivityMutation = useMutation({
@@ -579,13 +589,22 @@ export function useSetProgress(planId: string | null, weekNumber: number) {
 
     /**
      * Add a single set to an exercise
+     * @param exerciseId - The exercise ID
+     * @param targetSets - The target number of sets
+     * @param overrideWorkoutId - Optional override for workout ID (used by workout picker)
      */
     const addSet = useCallback(
-        (exerciseId: string, targetSets: number) => {
+        (exerciseId: string, targetSets: number, overrideWorkoutId?: string) => {
             if (!planId) return;
 
-            // Update store
-            incrementSet(planId, weekNumber, exerciseId, targetSets);
+            const effectiveWorkoutId = overrideWorkoutId ?? workoutId;
+
+            // Update store (workout-specific or general)
+            if (effectiveWorkoutId) {
+                incrementSetForWorkout(planId, weekNumber, exerciseId, effectiveWorkoutId, targetSets);
+            } else {
+                incrementSet(planId, weekNumber, exerciseId, targetSets);
+            }
             syncPlanToServer(planId);
 
             // Create activity log
@@ -597,18 +616,26 @@ export function useSetProgress(planId: string | null, weekNumber: number) {
                 activityIds,
             });
         },
-        [planId, weekNumber, incrementSet, addActivityMutation]
+        [planId, weekNumber, workoutId, incrementSet, incrementSetForWorkout, addActivityMutation]
     );
 
     /**
      * Remove a set from an exercise
+     * @param exerciseId - The exercise ID
+     * @param overrideWorkoutId - Optional override for workout ID
      */
     const removeSet = useCallback(
-        (exerciseId: string) => {
+        (exerciseId: string, overrideWorkoutId?: string) => {
             if (!planId) return;
 
-            // Update store
-            decrementSet(planId, weekNumber, exerciseId);
+            const effectiveWorkoutId = overrideWorkoutId ?? workoutId;
+
+            // Update store (workout-specific or general)
+            if (effectiveWorkoutId) {
+                decrementSetForWorkout(planId, weekNumber, exerciseId, effectiveWorkoutId);
+            } else {
+                decrementSet(planId, weekNumber, exerciseId);
+            }
             syncPlanToServer(planId);
 
             // Delete activity log
@@ -617,7 +644,7 @@ export function useSetProgress(planId: string | null, weekNumber: number) {
                 date: new Date().toISOString().split('T')[0],
             });
         },
-        [planId, weekNumber, decrementSet, deleteRecentActivityMutation]
+        [planId, weekNumber, workoutId, decrementSet, decrementSetForWorkout, deleteRecentActivityMutation]
     );
 
     /**

--- a/src/client/features/plan-data/index.ts
+++ b/src/client/features/plan-data/index.ts
@@ -27,6 +27,8 @@ export {
     usePlanIsDirty,
     usePlanConflict,
     usePlanHasConflict,
+    useWorkoutSetsForExercise,
+    useWeekWorkoutSets,
 } from './store';
 
 // Sync functions

--- a/src/client/features/plan-data/store.ts
+++ b/src/client/features/plan-data/store.ts
@@ -69,13 +69,24 @@ interface PlanDataState {
     // ========================================================================
     // Progress Actions (used by Home)
     // ========================================================================
-    
+
     /** Increment sets completed for an exercise */
     incrementSet: (planId: string, weekNumber: number, exerciseId: string, targetSets: number) => void;
     /** Decrement sets completed for an exercise */
     decrementSet: (planId: string, weekNumber: number, exerciseId: string) => void;
     /** Complete all remaining sets for an exercise */
     completeAllSets: (planId: string, weekNumber: number, exerciseId: string, targetSets: number) => void;
+
+    // ========================================================================
+    // Workout-Specific Progress Actions
+    // ========================================================================
+
+    /** Increment sets for a specific workout (also updates total) */
+    incrementSetForWorkout: (planId: string, weekNumber: number, exerciseId: string, workoutId: string, targetSets: number) => void;
+    /** Decrement sets for a specific workout (also updates total) */
+    decrementSetForWorkout: (planId: string, weekNumber: number, exerciseId: string, workoutId: string) => void;
+    /** Get sets completed for a specific workout */
+    getWorkoutSets: (planId: string, weekNumber: number, workoutId: string, exerciseId: string) => number;
 
     // ========================================================================
     // Cache Management
@@ -92,6 +103,7 @@ interface PlanDataState {
 const createEmptyPlanData = (): PlanData => ({
     exercises: [],
     weekProgress: {},
+    workoutSets: {},
     lastSyncedAt: null,
     isDirty: false,
 });
@@ -364,7 +376,7 @@ export const usePlanDataStore = createStore<PlanDataState>({
 
                 const weekProgress = { ...plan.weekProgress };
                 const currentWeek = weekProgress[weekNumber] || {};
-                
+
                 weekProgress[weekNumber] = {
                     ...currentWeek,
                     [exerciseId]: {
@@ -380,6 +392,105 @@ export const usePlanDataStore = createStore<PlanDataState>({
                     },
                 };
             });
+        },
+
+        // ====================================================================
+        // Workout-Specific Progress Actions
+        // ====================================================================
+
+        incrementSetForWorkout: (planId, weekNumber, exerciseId, workoutId, targetSets) => {
+            set((state) => {
+                const plan = state.plans[planId];
+                if (!plan) return state;
+
+                // Update total progress (same as incrementSet)
+                const weekProgress = { ...plan.weekProgress };
+                const currentWeek = weekProgress[weekNumber] || {};
+                const current = currentWeek[exerciseId] || { setsCompleted: 0, isDone: false };
+
+                const newSetsCompleted = Math.min(current.setsCompleted + 1, targetSets);
+                const newProgress: ExerciseProgress = {
+                    setsCompleted: newSetsCompleted,
+                    isDone: newSetsCompleted >= targetSets,
+                };
+
+                weekProgress[weekNumber] = {
+                    ...currentWeek,
+                    [exerciseId]: newProgress,
+                };
+
+                // Update workout-specific sets
+                const workoutSets = { ...plan.workoutSets };
+                const weekWorkouts = workoutSets[weekNumber] || {};
+                const workoutExercises = weekWorkouts[workoutId] || {};
+                const currentWorkoutSets = workoutExercises[exerciseId] || 0;
+
+                workoutSets[weekNumber] = {
+                    ...weekWorkouts,
+                    [workoutId]: {
+                        ...workoutExercises,
+                        [exerciseId]: currentWorkoutSets + 1,
+                    },
+                };
+
+                return {
+                    plans: {
+                        ...state.plans,
+                        [planId]: { ...plan, weekProgress, workoutSets, isDirty: true },
+                    },
+                };
+            });
+        },
+
+        decrementSetForWorkout: (planId, weekNumber, exerciseId, workoutId) => {
+            set((state) => {
+                const plan = state.plans[planId];
+                if (!plan) return state;
+
+                // Update total progress (same as decrementSet)
+                const weekProgress = { ...plan.weekProgress };
+                const currentWeek = weekProgress[weekNumber] || {};
+                const current = currentWeek[exerciseId] || { setsCompleted: 0, isDone: false };
+
+                const newSetsCompleted = Math.max(current.setsCompleted - 1, 0);
+                const newProgress: ExerciseProgress = {
+                    setsCompleted: newSetsCompleted,
+                    isDone: false, // Can't be done if we just removed a set
+                };
+
+                weekProgress[weekNumber] = {
+                    ...currentWeek,
+                    [exerciseId]: newProgress,
+                };
+
+                // Update workout-specific sets
+                const workoutSets = { ...plan.workoutSets };
+                const weekWorkouts = workoutSets[weekNumber] || {};
+                const workoutExercises = weekWorkouts[workoutId] || {};
+                const currentWorkoutSets = workoutExercises[exerciseId] || 0;
+
+                workoutSets[weekNumber] = {
+                    ...weekWorkouts,
+                    [workoutId]: {
+                        ...workoutExercises,
+                        [exerciseId]: Math.max(currentWorkoutSets - 1, 0),
+                    },
+                };
+
+                return {
+                    plans: {
+                        ...state.plans,
+                        [planId]: { ...plan, weekProgress, workoutSets, isDirty: true },
+                    },
+                };
+            });
+        },
+
+        getWorkoutSets: (planId, weekNumber, workoutId, exerciseId) => {
+            const state = usePlanDataStore.getState();
+            const plan = state.plans[planId];
+            if (!plan) return 0;
+            return plan.workoutSets?.[weekNumber]?.[workoutId]?.[exerciseId] || 0;
         },
 
         // ====================================================================
@@ -484,7 +595,35 @@ export function usePlanConflict(planId: string | null): PlanConflict | null {
  * Check if plan has a sync conflict
  */
 export function usePlanHasConflict(planId: string | null): boolean {
-    return usePlanDataStore((state) => 
+    return usePlanDataStore((state) =>
         planId ? !!state.conflicts[planId] : false
     );
+}
+
+/**
+ * Get workout-specific sets for an exercise
+ */
+export function useWorkoutSetsForExercise(
+    planId: string | null,
+    weekNumber: number,
+    workoutId: string | null,
+    exerciseId: string
+): number {
+    return usePlanDataStore((state) => {
+        if (!planId || !workoutId) return 0;
+        return state.plans[planId]?.workoutSets?.[weekNumber]?.[workoutId]?.[exerciseId] ?? 0;
+    });
+}
+
+/**
+ * Get all workout sets for a week (for calculating totals)
+ */
+export function useWeekWorkoutSets(
+    planId: string | null,
+    weekNumber: number
+): Record<string, Record<string, number>> {
+    return usePlanDataStore((state) => {
+        if (!planId) return {};
+        return state.plans[planId]?.workoutSets?.[weekNumber] ?? {};
+    });
 }

--- a/src/client/features/plan-data/types.ts
+++ b/src/client/features/plan-data/types.ts
@@ -30,6 +30,8 @@ export interface PlanData {
     exercises: PlanExerciseWithDefinition[];
     /** Week progress: {weekNumber: {planExerciseId: ExerciseProgress}} */
     weekProgress: Record<number, Record<string, ExerciseProgress>>;
+    /** Workout-specific sets: {weekNumber: {workoutId: {planExerciseId: setsCompleted}}} */
+    workoutSets: Record<number, Record<string, Record<string, number>>>;
     /** Timestamp when data was last synced to server */
     lastSyncedAt: number | null;
     /** Whether local data has unsaved changes */

--- a/src/client/routes/ActiveWorkout/ActiveWorkout.tsx
+++ b/src/client/routes/ActiveWorkout/ActiveWorkout.tsx
@@ -120,7 +120,8 @@ export function ActiveWorkout() {
     const createPlanWorkoutMutation = useCreatePlanWorkout(activePlanId || '');
 
     // Set progress actions (unified store + activity logging)
-    const { addSet, removeSet } = useSetProgress(activePlanId, currentWeek);
+    // Pass planWorkoutId to track sets for this specific workout
+    const { addSet, removeSet } = useSetProgress(activePlanId, currentWeek, planWorkoutId);
 
     // Plan exercises (for adding exercises during workout - always available with active plan)
     const { data: weekProgressData } = useWeekProgress(activePlanId, currentWeek);

--- a/src/client/routes/Home/Home.tsx
+++ b/src/client/routes/Home/Home.tsx
@@ -47,6 +47,7 @@ import {
     useWeekProgressFromStoreData,
     usePlanLoading,
     useSetProgress,
+    useWeekWorkoutSets,
     type ExerciseWeekProgressFromStore,
 } from '@/client/features/plan-data';
 import { usePlanWorkouts } from '@/client/features/plan-workouts';
@@ -94,6 +95,9 @@ export function Home() {
     // Plan workouts data (scoped to active plan)
     const { data: planWorkoutsData, isLoading: planWorkoutsLoading } = usePlanWorkouts(activePlanId);
 
+    // Workout-specific sets for all workouts in the current week
+    const weekWorkoutSets = useWeekWorkoutSets(activePlanId, currentWeek);
+
     // Detect mobile viewport (matches Tailwind's sm: breakpoint at 640px)
     // Used to position selection bar above the bottom navbar on mobile
     const isMobile = useMemo(() => {
@@ -133,19 +137,201 @@ export function Home() {
         }
     };
 
+    // =========================================================================
+    // AUTO-FILL SET ALLOCATION LOGIC
+    // =========================================================================
+    //
+    // Strategy: When a user adds/removes sets from the Exercise Tab or an ad-hoc
+    // workout (not a saved workout), we automatically assign sets to workouts
+    // WITHOUT prompting the user.
+    //
+    // - ADDING SETS: Fill workouts in order (first → last) until each reaches
+    //   its allocated capacity, then move to the next workout.
+    //   Example: Exercise has 10 sets split into Workout A (5) and Workout B (5).
+    //   First 5 sets go to Workout A, next 5 go to Workout B.
+    //
+    // - REMOVING SETS: Remove from last workout first (last → first), reversing
+    //   the add order for intuitive LIFO behavior.
+    //   Example: If Workout A has 5/5 and Workout B has 3/5, removing a set
+    //   decrements Workout B first (to 2/5).
+    //
+    // - If exercise is not in any saved workout, workoutId is null and only
+    //   the total weekly progress is updated (no per-workout tracking).
+    //
+    // =========================================================================
 
+    /**
+     * Find the first workout with remaining capacity for an exercise.
+     * Used when ADDING sets - fills workouts in order (first to last).
+     *
+     * @returns workoutId of first workout with capacity, or null if:
+     *   - Exercise is not in any saved workout
+     *   - All workouts are already at full capacity
+     */
+    const getFirstWorkoutWithCapacity = (exerciseId: string): string | null => {
+        // Step 1: Get all saved workouts that include this exercise
+        const containingWorkouts = planWorkoutsList.filter((workout) =>
+            workout.items.some((item) => item.planExerciseId === exerciseId)
+        );
+
+        // No workouts contain this exercise - return null (only total will be updated)
+        if (containingWorkouts.length === 0) return null;
+
+        // Step 2: Iterate through workouts in order to find first with capacity
+        for (const workout of containingWorkouts) {
+            const item = workout.items.find((i) => i.planExerciseId === exerciseId);
+            if (!item) continue;
+
+            // Get how many sets this workout should have for this exercise
+            // item.sets = per-workout allocation (e.g., 5 sets for this workout)
+            // Falls back to exercise's total weekly sets if no specific allocation
+            const exercise = exercises.find((e) => e.planExerciseId === exerciseId);
+            const allocatedSets = item.sets ?? exercise?.targetSets ?? 0;
+
+            // Get how many sets have already been completed in THIS workout
+            const completedInWorkout = weekWorkoutSets[workout._id]?.[exerciseId] ?? 0;
+
+            // If there's room in this workout, assign the new set here
+            if (completedInWorkout < allocatedSets) {
+                return workout._id;
+            }
+            // Otherwise, continue to check the next workout
+        }
+
+        // All workouts are at capacity - return null (only total will be updated)
+        return null;
+    };
+
+    /**
+     * Find the last workout with completed sets for an exercise.
+     * Used when REMOVING sets - removes from last workout first (LIFO order).
+     *
+     * @returns workoutId of last workout with sets, or null if:
+     *   - Exercise is not in any saved workout
+     *   - No workout has any completed sets for this exercise
+     */
+    const getLastWorkoutWithSets = (exerciseId: string): string | null => {
+        // Step 1: Get all saved workouts that include this exercise
+        const containingWorkouts = planWorkoutsList.filter((workout) =>
+            workout.items.some((item) => item.planExerciseId === exerciseId)
+        );
+
+        // No workouts contain this exercise - return null (only total will be updated)
+        if (containingWorkouts.length === 0) return null;
+
+        // Step 2: Iterate through workouts in REVERSE order to find last with sets
+        // This ensures LIFO behavior: last workout to receive sets loses them first
+        for (let i = containingWorkouts.length - 1; i >= 0; i--) {
+            const workout = containingWorkouts[i];
+            const completedInWorkout = weekWorkoutSets[workout._id]?.[exerciseId] ?? 0;
+
+            // If this workout has any completed sets, remove from here
+            if (completedInWorkout > 0) {
+                return workout._id;
+            }
+            // Otherwise, continue checking earlier workouts
+        }
+
+        // No workout has any sets to remove - return null (only total will be updated)
+        return null;
+    };
+
+    /**
+     * Handle adding a set from the Exercise Tab or ad-hoc workout.
+     * Uses auto-fill logic to assign to the first workout with capacity.
+     */
     const handleAddSet = (exercise: ExerciseWeekProgressFromStore) => {
+        // Guard: Don't exceed the exercise's total weekly target
         if (exercise.setsCompleted >= exercise.targetSets) return;
-        addSet(exercise.planExerciseId, exercise.targetSets);
+
+        // Find the first workout with remaining capacity for this exercise
+        // If null, the set will only be added to the total (not tracked per-workout)
+        const workoutId = getFirstWorkoutWithCapacity(exercise.planExerciseId);
+
+        // addSet updates both:
+        // 1. Total weekly progress (weekProgress[week][exerciseId].setsCompleted)
+        // 2. Per-workout progress if workoutId is provided (workoutSets[week][workoutId][exerciseId])
+        addSet(exercise.planExerciseId, exercise.targetSets, workoutId ?? undefined);
     };
 
+    /**
+     * Handle removing a set from the Exercise Tab or ad-hoc workout.
+     * Uses reverse order (LIFO) to remove from the last workout first.
+     */
     const handleRemoveSet = (exercise: ExerciseWeekProgressFromStore) => {
+        // Guard: Can't remove below zero
         if (exercise.setsCompleted <= 0) return;
-        removeSet(exercise.planExerciseId);
+
+        // Find the last workout that has sets for this exercise
+        // If null, only the total will be decremented (not tracked per-workout)
+        const workoutId = getLastWorkoutWithSets(exercise.planExerciseId);
+
+        // removeSet updates both:
+        // 1. Total weekly progress (weekProgress[week][exerciseId].setsCompleted)
+        // 2. Per-workout progress if workoutId is provided (workoutSets[week][workoutId][exerciseId])
+        removeSet(exercise.planExerciseId, workoutId ?? undefined);
     };
 
+    /**
+     * Handle completing all remaining sets for an exercise.
+     * Uses the same auto-fill logic as handleAddSet to distribute sets across workouts.
+     *
+     * Note: We track allocations locally because React state won't update between
+     * loop iterations (batched updates). This mirrors the auto-fill logic but
+     * accounts for sets we're adding within this same call.
+     */
     const handleCompleteAll = (exercise: ExerciseWeekProgressFromStore) => {
-        completeAllSets(exercise.planExerciseId, exercise.targetSets, exercise.setsCompleted);
+        const remainingSets = exercise.targetSets - exercise.setsCompleted;
+        if (remainingSets <= 0) return;
+
+        const exerciseId = exercise.planExerciseId;
+
+        // Get workouts containing this exercise (same as getFirstWorkoutWithCapacity)
+        const containingWorkouts = planWorkoutsList.filter((workout) =>
+            workout.items.some((item) => item.planExerciseId === exerciseId)
+        );
+
+        // If exercise isn't in any workout, just add sets without workout tracking
+        if (containingWorkouts.length === 0) {
+            for (let i = 0; i < remainingSets; i++) {
+                addSet(exerciseId, exercise.targetSets, undefined);
+            }
+            return;
+        }
+
+        // Track allocations locally to account for sets we're adding in this loop
+        // (React state won't update between iterations due to batching)
+        const localAllocations: Record<string, number> = {};
+        for (const workout of containingWorkouts) {
+            localAllocations[workout._id] = weekWorkoutSets[workout._id]?.[exerciseId] ?? 0;
+        }
+
+        // Distribute remaining sets across workouts using auto-fill logic
+        for (let i = 0; i < remainingSets; i++) {
+            // Find first workout with capacity (same logic as getFirstWorkoutWithCapacity)
+            let targetWorkoutId: string | undefined;
+            for (const workout of containingWorkouts) {
+                const item = workout.items.find((it) => it.planExerciseId === exerciseId);
+                if (!item) continue;
+
+                const ex = exercises.find((e) => e.planExerciseId === exerciseId);
+                const allocatedSets = item.sets ?? ex?.targetSets ?? 0;
+                const completedInWorkout = localAllocations[workout._id];
+
+                if (completedInWorkout < allocatedSets) {
+                    targetWorkoutId = workout._id;
+                    break;
+                }
+            }
+
+            // Add the set
+            addSet(exerciseId, exercise.targetSets, targetWorkoutId);
+
+            // Update local tracking so next iteration knows about this allocation
+            if (targetWorkoutId) {
+                localAllocations[targetWorkoutId]++;
+            }
+        }
     };
 
     const handleOpenExerciseDetails = (exercise: ExerciseWeekProgressFromStore) => {
@@ -563,6 +749,7 @@ export function Home() {
                                     key={workout._id}
                                     workout={workout}
                                     exercises={exercises}
+                                    workoutSets={weekWorkoutSets[workout._id] || {}}
                                     isExpanded={expandedWorkoutId === workout._id}
                                     onToggleExpand={() => setExpandedWorkoutId(
                                         expandedWorkoutId === workout._id ? null : workout._id

--- a/src/client/routes/Home/components/PlanWorkoutCard.tsx
+++ b/src/client/routes/Home/components/PlanWorkoutCard.tsx
@@ -12,6 +12,8 @@ import { ExerciseCardList } from './ExerciseCard';
 export interface PlanWorkoutCardProps {
     workout: PlanWorkoutClient;
     exercises: ExerciseWeekProgressFromStore[];
+    /** Workout-specific sets: {exerciseId: setsCompleted} for this workout */
+    workoutSets?: Record<string, number>;
     onStart: () => void;
     isExpanded: boolean;
     onToggleExpand: () => void;
@@ -27,6 +29,7 @@ export interface PlanWorkoutCardProps {
 export function PlanWorkoutCard({
     workout,
     exercises,
+    workoutSets = {},
     onStart,
     isExpanded,
     onToggleExpand,
@@ -40,14 +43,27 @@ export function PlanWorkoutCard({
     // Create a map for quick lookup of exercises by planExerciseId
     const exerciseMap = new Map(exercises.map((ex) => [ex.planExerciseId, ex]));
 
-    // Resolve workout items to exercises with definitions
+    // Resolve workout items to exercises with workout-specific target sets and completed sets
+    // item.sets is the per-workout allocation (undefined means use exercise's weekly sets)
     const resolvedExercises = workout.items
-        .map((item) => exerciseMap.get(item.planExerciseId))
-        .filter((ex): ex is ExerciseWeekProgressFromStore => ex !== undefined);
+        .map((item) => {
+            const ex = exerciseMap.get(item.planExerciseId);
+            if (!ex) return null;
+            // Use workout-specific sets if defined, otherwise fall back to exercise's weekly sets
+            const workoutTargetSets = item.sets ?? ex.targetSets;
+            // Get workout-specific completed sets (not total)
+            const workoutSetsCompleted = workoutSets[item.planExerciseId] ?? 0;
+            return {
+                ...ex,
+                workoutTargetSets,
+                workoutSetsCompleted,
+            };
+        })
+        .filter((ex): ex is ExerciseWeekProgressFromStore & { workoutTargetSets: number; workoutSetsCompleted: number } => ex !== null);
 
-    // Calculate workout progress
-    const totalSets = resolvedExercises.reduce((sum, ex) => sum + ex.targetSets, 0);
-    const completedSets = resolvedExercises.reduce((sum, ex) => sum + Math.min(ex.setsCompleted, ex.targetSets), 0);
+    // Calculate workout progress using workout-specific completed sets
+    const totalSets = resolvedExercises.reduce((sum, ex) => sum + ex.workoutTargetSets, 0);
+    const completedSets = resolvedExercises.reduce((sum, ex) => sum + Math.min(ex.workoutSetsCompleted, ex.workoutTargetSets), 0);
     const progressPercent = totalSets > 0 ? Math.round((completedSets / totalSets) * 100) : 0;
     const isWorkoutComplete = totalSets > 0 && completedSets >= totalSets;
 
@@ -119,11 +135,18 @@ export function PlanWorkoutCard({
                             </div>
                         ) : (
                             resolvedExercises.map((ex) => {
-                                const isExerciseDone = ex.isDone || ex.setsCompleted >= ex.targetSets;
+                                // Use workout-specific completed sets for completion status
+                                const isExerciseDone = ex.workoutSetsCompleted >= ex.workoutTargetSets;
+                                // Create a modified exercise object with workout-specific progress for display
+                                const displayExercise = {
+                                    ...ex,
+                                    setsCompleted: ex.workoutSetsCompleted,
+                                    targetSets: ex.workoutTargetSets,
+                                };
                                 return (
                                     <ExerciseCardList
                                         key={ex.planExerciseId}
-                                        exercise={ex}
+                                        exercise={displayExercise}
                                         onAddSet={() => onAddSet(ex)}
                                         onRemoveSet={() => onRemoveSet(ex)}
                                         onCompleteAll={() => onCompleteAll(ex)}

--- a/src/client/routes/ManagePlan/components/workouts/WorkoutDialog.tsx
+++ b/src/client/routes/ManagePlan/components/workouts/WorkoutDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import Image from 'next/image';
 import { Button } from '@/client/components/ui/button';
 import { Input } from '@/client/components/ui/input';
@@ -8,7 +8,7 @@ import {
     DialogHeader,
     DialogTitle,
 } from '@/client/components/ui/dialog';
-import { Check, Dumbbell } from 'lucide-react';
+import { Check, Dumbbell, AlertTriangle } from 'lucide-react';
 import type { PlanExerciseWithDefinition } from '@/apis/plan-exercises/types';
 import type { PlanWorkoutClient } from '@/apis/plan-workouts/types';
 
@@ -17,7 +17,8 @@ interface WorkoutDialogProps {
     onOpenChange: (open: boolean) => void;
     editingWorkout: PlanWorkoutClient | null;
     planExercises: PlanExerciseWithDefinition[];
-    onSave: (name: string, exerciseIds: Set<string>) => void;
+    planWorkouts: PlanWorkoutClient[];
+    onSave: (name: string, items: Array<{ planExerciseId: string; order: number; sets?: number }>) => void;
     isPending: boolean;
 }
 
@@ -26,59 +27,122 @@ export function WorkoutDialog({
     onOpenChange,
     editingWorkout,
     planExercises,
+    planWorkouts,
     onSave,
     isPending,
 }: WorkoutDialogProps) {
     // eslint-disable-next-line state-management/prefer-state-architecture -- ephemeral form input
     const [workoutName, setWorkoutName] = useState('');
-    // eslint-disable-next-line state-management/prefer-state-architecture -- ephemeral selection
-    const [selectedExercises, setSelectedExercises] = useState<Set<string>>(new Set());
+    // eslint-disable-next-line state-management/prefer-state-architecture -- ephemeral selection with sets
+    // Map of planExerciseId -> sets (undefined means use exercise's weekly sets)
+    const [selectedExercises, setSelectedExercises] = useState<Map<string, number | undefined>>(new Map());
+
+    // Calculate allocated sets per exercise across all workouts (excluding current editing workout)
+    const allocationMap = useMemo(() => {
+        const allocations = new Map<string, number>();
+
+        for (const workout of planWorkouts) {
+            // Skip current workout when editing
+            if (editingWorkout && workout._id === editingWorkout._id) continue;
+
+            for (const item of workout.items) {
+                // Use item.sets if defined, otherwise use exercise's weekly sets
+                const exercise = planExercises.find(pe => pe._id === item.planExerciseId);
+                const sets = item.sets ?? exercise?.sets ?? 0;
+                const current = allocations.get(item.planExerciseId) || 0;
+                allocations.set(item.planExerciseId, current + sets);
+            }
+        }
+
+        return allocations;
+    }, [planWorkouts, editingWorkout, planExercises]);
 
     // Reset form when dialog opens or editingWorkout changes
     useEffect(() => {
         if (open) {
             if (editingWorkout) {
                 setWorkoutName(editingWorkout.name);
-                // Select exercises that are in this workout's items
-                const workoutPlanExerciseIds = new Set(
-                    editingWorkout.items.map((item) => item.planExerciseId)
-                );
-                // Only include IDs that still exist in planExercises
-                const validIds = planExercises
-                    .filter((pe) => workoutPlanExerciseIds.has(pe._id))
-                    .map((pe) => pe._id);
-                setSelectedExercises(new Set(validIds));
+                // Select exercises with their sets from the editing workout
+                const exerciseMap = new Map<string, number | undefined>();
+                for (const item of editingWorkout.items) {
+                    // Only include IDs that still exist in planExercises
+                    const exercise = planExercises.find(pe => pe._id === item.planExerciseId);
+                    if (exercise) {
+                        // Use item.sets if defined, otherwise use exercise's weekly sets as default
+                        exerciseMap.set(item.planExerciseId, item.sets ?? exercise.sets);
+                    }
+                }
+                setSelectedExercises(exerciseMap);
             } else {
                 setWorkoutName('');
-                setSelectedExercises(new Set());
+                setSelectedExercises(new Map());
             }
         }
     }, [open, editingWorkout, planExercises]);
 
-    const handleToggleExercise = (exerciseId: string) => {
+    const handleToggleExercise = (exerciseId: string, exercise: PlanExerciseWithDefinition) => {
         setSelectedExercises((prev) => {
-            const newSet = new Set(prev);
-            if (newSet.has(exerciseId)) {
-                newSet.delete(exerciseId);
+            const newMap = new Map(prev);
+            if (newMap.has(exerciseId)) {
+                newMap.delete(exerciseId);
             } else {
-                newSet.add(exerciseId);
+                // Default to remaining sets (what's not allocated to other workouts)
+                const allocated = allocationMap.get(exerciseId) || 0;
+                const remaining = Math.max(0, exercise.sets - allocated);
+                // If all sets are allocated, default to exercise's weekly sets
+                newMap.set(exerciseId, remaining > 0 ? remaining : exercise.sets);
             }
-            return newSet;
+            return newMap;
+        });
+    };
+
+    const handleSetsChange = (exerciseId: string, sets: number) => {
+        setSelectedExercises((prev) => {
+            const newMap = new Map(prev);
+            newMap.set(exerciseId, Math.max(0, sets));
+            return newMap;
         });
     };
 
     const handleSelectAll = () => {
-        setSelectedExercises(new Set(planExercises.map((ex) => ex._id)));
+        const newMap = new Map<string, number | undefined>();
+        for (const exercise of planExercises) {
+            const allocated = allocationMap.get(exercise._id) || 0;
+            const remaining = Math.max(0, exercise.sets - allocated);
+            newMap.set(exercise._id, remaining > 0 ? remaining : exercise.sets);
+        }
+        setSelectedExercises(newMap);
     };
 
     const handleDeselectAll = () => {
-        setSelectedExercises(new Set());
+        setSelectedExercises(new Map());
     };
 
     const handleSave = () => {
         if (!workoutName.trim() || selectedExercises.size === 0) return;
-        onSave(workoutName.trim(), selectedExercises);
+
+        // Build items array with proper order
+        const items = Array.from(selectedExercises.entries()).map(([planExerciseId, sets], index) => ({
+            planExerciseId,
+            order: index,
+            sets,
+        }));
+
+        onSave(workoutName.trim(), items);
     };
+
+    // Calculate total over-allocation warning
+    const hasOverAllocation = useMemo(() => {
+        for (const [exerciseId, sets] of selectedExercises) {
+            const exercise = planExercises.find(e => e._id === exerciseId);
+            if (!exercise) continue;
+            const alreadyAllocated = allocationMap.get(exerciseId) || 0;
+            if (alreadyAllocated + (sets ?? exercise.sets) > exercise.sets) {
+                return true;
+            }
+        }
+        return false;
+    }, [selectedExercises, allocationMap, planExercises]);
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
@@ -136,52 +200,99 @@ export function WorkoutDialog({
                     <div className="flex-1 overflow-y-auto p-4 space-y-2 min-h-0">
                         {planExercises.map((exercise) => {
                             const isSelected = selectedExercises.has(exercise._id);
+                            const selectedSets = selectedExercises.get(exercise._id) ?? exercise.sets;
+                            const alreadyAllocated = allocationMap.get(exercise._id) || 0;
+                            const isFullyAllocated = alreadyAllocated >= exercise.sets;
+                            const totalWithThis = alreadyAllocated + (isSelected ? selectedSets : 0);
+                            const isOverAllocated = totalWithThis > exercise.sets;
+
                             return (
                                 <div
                                     key={exercise._id}
-                                    onClick={() => handleToggleExercise(exercise._id)}
-                                    className={`flex items-center gap-3 p-3 rounded-xl cursor-pointer transition-all active:scale-[0.98] ${
+                                    className={`rounded-xl transition-all ${
                                         isSelected
                                             ? 'bg-primary/10 ring-1 ring-primary/30'
-                                            : 'bg-background hover:bg-background/80'
+                                            : isFullyAllocated
+                                                ? 'bg-muted/50 opacity-60'
+                                                : 'bg-background hover:bg-background/80'
                                     }`}
                                 >
-                                    {/* Checkbox */}
-                                    <div className={`w-6 h-6 rounded-lg border-2 flex items-center justify-center transition-all flex-shrink-0 ${
-                                        isSelected
-                                            ? 'bg-primary border-primary scale-110'
-                                            : 'border-muted-foreground/20 bg-background'
-                                    }`}>
-                                        {isSelected && <Check className="h-4 w-4 text-primary-foreground" strokeWidth={3} />}
-                                    </div>
+                                    <div
+                                        onClick={() => handleToggleExercise(exercise._id, exercise)}
+                                        className="flex items-center gap-3 p-3 cursor-pointer active:scale-[0.98]"
+                                    >
+                                        {/* Checkbox */}
+                                        <div className={`w-6 h-6 rounded-lg border-2 flex items-center justify-center transition-all flex-shrink-0 ${
+                                            isSelected
+                                                ? 'bg-primary border-primary scale-110'
+                                                : 'border-muted-foreground/20 bg-background'
+                                        }`}>
+                                            {isSelected && <Check className="h-4 w-4 text-primary-foreground" strokeWidth={3} />}
+                                        </div>
 
-                                    {/* Exercise image */}
-                                    <div className="w-12 h-12 rounded-xl bg-muted overflow-hidden flex-shrink-0 relative border border-border/50">
-                                        {exercise.exerciseDef.imageUrl ? (
-                                            <Image
-                                                src={exercise.exerciseDef.imageUrl}
-                                                alt={exercise.exerciseDef.name}
-                                                fill
-                                                className="object-contain p-1"
-                                                unoptimized
-                                            />
-                                        ) : (
-                                            <div className="w-full h-full flex items-center justify-center">
-                                                <Dumbbell className="h-5 w-5 text-muted-foreground" />
+                                        {/* Exercise image */}
+                                        <div className="w-12 h-12 rounded-xl bg-muted overflow-hidden flex-shrink-0 relative border border-border/50">
+                                            {exercise.exerciseDef.imageUrl ? (
+                                                <Image
+                                                    src={exercise.exerciseDef.imageUrl}
+                                                    alt={exercise.exerciseDef.name}
+                                                    fill
+                                                    className="object-contain p-1"
+                                                    unoptimized
+                                                />
+                                            ) : (
+                                                <div className="w-full h-full flex items-center justify-center">
+                                                    <Dumbbell className="h-5 w-5 text-muted-foreground" />
+                                                </div>
+                                            )}
+                                        </div>
+
+                                        {/* Exercise info */}
+                                        <div className="flex-1 min-w-0">
+                                            <h4 className={`font-medium truncate ${isSelected ? 'text-primary' : ''}`}>
+                                                {exercise.exerciseDef.name}
+                                            </h4>
+                                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                                <span>
+                                                    {exercise.reps} reps
+                                                    {exercise.weight > 0 && ` · ${exercise.weight}kg`}
+                                                </span>
+                                                <span className="text-muted-foreground/50">·</span>
+                                                <span className={`${
+                                                    isOverAllocated
+                                                        ? 'text-warning'
+                                                        : isFullyAllocated
+                                                            ? 'text-success'
+                                                            : ''
+                                                }`}>
+                                                    {alreadyAllocated}/{exercise.sets} allocated
+                                                    {isFullyAllocated && !isSelected && ' ✓'}
+                                                </span>
                                             </div>
-                                        )}
+                                        </div>
                                     </div>
 
-                                    {/* Exercise info */}
-                                    <div className="flex-1 min-w-0">
-                                        <h4 className={`font-medium truncate ${isSelected ? 'text-primary' : ''}`}>
-                                            {exercise.exerciseDef.name}
-                                        </h4>
-                                        <p className="text-sm text-muted-foreground">
-                                            {exercise.sets} × {exercise.reps}
-                                            {exercise.weight > 0 && ` · ${exercise.weight}kg`}
-                                        </p>
-                                    </div>
+                                    {/* Sets input (shown when selected) */}
+                                    {isSelected && (
+                                        <div className="px-3 pb-3 flex items-center gap-2">
+                                            <span className="text-sm text-muted-foreground ml-9">Sets:</span>
+                                            <Input
+                                                type="number"
+                                                min={0}
+                                                max={exercise.sets}
+                                                value={selectedSets}
+                                                onChange={(e) => handleSetsChange(exercise._id, parseInt(e.target.value) || 0)}
+                                                onClick={(e) => e.stopPropagation()}
+                                                className="w-20 h-8 text-center"
+                                            />
+                                            <span className="text-sm text-muted-foreground">
+                                                / {exercise.sets} weekly
+                                            </span>
+                                            {isOverAllocated && (
+                                                <AlertTriangle className="h-4 w-4 text-warning ml-auto" />
+                                            )}
+                                        </div>
+                                    )}
                                 </div>
                             );
                         })}
@@ -190,6 +301,12 @@ export function WorkoutDialog({
 
                 {/* Footer */}
                 <div className="p-4 border-t bg-background">
+                    {hasOverAllocation && (
+                        <div className="flex items-center gap-2 text-warning text-sm mb-3">
+                            <AlertTriangle className="h-4 w-4" />
+                            <span>Some exercises exceed their weekly allocation</span>
+                        </div>
+                    )}
                     <Button
                         onClick={handleSave}
                         disabled={!workoutName.trim() || selectedExercises.size === 0 || isPending}

--- a/src/client/routes/ManagePlan/components/workouts/WorkoutsTab.tsx
+++ b/src/client/routes/ManagePlan/components/workouts/WorkoutsTab.tsx
@@ -19,14 +19,14 @@ interface WorkoutsTabProps {
     // Mutations
     createWorkoutMutation: {
         mutate: (
-            params: { planId: string; name: string; items: Array<{ planExerciseId: string; order: number }> },
+            params: { planId: string; name: string; items: Array<{ planExerciseId: string; order: number; sets?: number }> },
             options?: { onSuccess?: () => void; onError?: (error: Error) => void }
         ) => void;
         isPending: boolean;
     };
     updateWorkoutMutation: {
         mutate: (
-            params: { planId: string; workoutId: string; name?: string; items?: Array<{ planExerciseId: string; order: number }> },
+            params: { planId: string; workoutId: string; name?: string; items?: Array<{ planExerciseId: string; order: number; sets?: number }> },
             options?: { onSuccess?: () => void; onError?: (error: Error) => void }
         ) => void;
         isPending: boolean;
@@ -76,18 +76,7 @@ export function WorkoutsTab({
         setWorkoutDialogOpen(true);
     };
 
-    const handleSaveWorkout = (name: string, selectedExerciseIds: Set<string>) => {
-        // Get selected exercises in their original order
-        const selectedPlanExercises = planExercises.filter((ex) =>
-            selectedExerciseIds.has(ex._id)
-        );
-
-        // Build items array with planExerciseId references
-        const items = selectedPlanExercises.map((ex, index) => ({
-            planExerciseId: ex._id,
-            order: index,
-        }));
-
+    const handleSaveWorkout = (name: string, items: Array<{ planExerciseId: string; order: number; sets?: number }>) => {
         if (editingWorkout) {
             updateWorkoutMutation.mutate(
                 {
@@ -155,10 +144,16 @@ export function WorkoutsTab({
             {
                 planId,
                 name: `${workout.name} (Copy)`,
-                items: workout.items.map((item, index) => ({
-                    planExerciseId: item.planExerciseId,
-                    order: index,
-                })),
+                items: workout.items.map((item, index) => {
+                    // Get exercise to use as fallback for sets
+                    const exercise = planExercises.find(pe => pe._id === item.planExerciseId);
+                    return {
+                        planExerciseId: item.planExerciseId,
+                        order: index,
+                        // Preserve sets if defined, otherwise use exercise's weekly sets
+                        sets: item.sets ?? exercise?.sets,
+                    };
+                }),
             },
             {
                 onSuccess: () => {
@@ -272,6 +267,7 @@ export function WorkoutsTab({
                 onOpenChange={setWorkoutDialogOpen}
                 editingWorkout={editingWorkout}
                 planExercises={planExercises}
+                planWorkouts={planWorkouts}
                 onSave={handleSaveWorkout}
                 isPending={createWorkoutMutation.isPending || updateWorkoutMutation.isPending}
             />

--- a/src/server/database/collections/planWorkouts/types.ts
+++ b/src/server/database/collections/planWorkouts/types.ts
@@ -7,6 +7,8 @@ import { ObjectId } from 'mongodb';
 export interface PlanWorkoutItem {
     planExerciseId: ObjectId | string;
     order: number;
+    /** Sets allocated to this workout (optional - defaults to exercise's weekly sets if not specified) */
+    sets?: number;
 }
 
 /**
@@ -37,6 +39,8 @@ export type PlanWorkoutUpdate = Partial<Omit<PlanWorkout, '_id' | 'userId' | 'pl
 export interface PlanWorkoutItemClient {
     planExerciseId: string;
     order: number;
+    /** Sets allocated to this workout (optional - defaults to exercise's weekly sets if not specified) */
+    sets?: number;
 }
 
 export interface PlanWorkoutClient {

--- a/src/server/database/collections/setLogs/types.ts
+++ b/src/server/database/collections/setLogs/types.ts
@@ -13,6 +13,8 @@ export interface SetLog {
     weekNumber: number;
     setNumber: number;
     completedAt: Date;
+    /** Optional workout ID - tracks which workout this set was completed in */
+    workoutId?: ObjectId | string;
 }
 
 /**
@@ -31,6 +33,8 @@ export interface SetLogClient {
     weekNumber: number;
     setNumber: number;
     completedAt: string;
+    /** Optional workout ID - tracks which workout this set was completed in */
+    workoutId?: string;
 }
 
 


### PR DESCRIPTION
## Summary
- Re-implements multi-workout exercise allocation with correct default behavior
- Adds workout-specific set tracking with simple auto-fill logic
- No user prompts - predictable, frictionless experience

## Key Features

### 1. Multi-Workout Allocation
- Exercises can be allocated to multiple workouts with custom set counts
- Default: exercise's weekly sets if not explicitly specified

### 2. Automatic Workout Assignment (No Dialogs)

| Scenario | Behavior |
|----------|----------|
| Exercise in 0 workouts | Update total only |
| Exercise in 1+ workouts | Auto-fill first workout with capacity |
| All workouts full | Update total only |
| Removing sets | Remove from last workout first |

**Example:** Exercise has 10 sets split into Workout A (5) and Workout B (5)

| Set # | Goes to | A progress | B progress |
|-------|---------|------------|------------|
| 1 | A | 1/5 | 0/5 |
| 2 | A | 2/5 | 0/5 |
| ... | A | .../5 | 0/5 |
| 5 | A | 5/5 ✓ | 0/5 |
| 6 | B | 5/5 ✓ | 1/5 |
| ... | B | 5/5 ✓ | .../5 |

### 3. Saved Workout Sessions
- Starting a saved workout tracks sets for that specific workout
- Ad-hoc workouts use the same auto-fill logic

## Data Storage

| Location | Purpose |
|----------|---------|
| `weekProgress[week][exercise]` | Total weekly sets (always updated) |
| `workoutSets[week][workout][exercise]` | Per-workout breakdown |

## Changes
- **Types**: Added `workoutSets` to PlanData, `workoutId` to SetLog
- **Store**: Added `incrementSetForWorkout`, `decrementSetForWorkout`
- **Home.tsx**: Auto-fill logic (no picker dialog)
- **PlanWorkoutCard**: Shows workout-specific progress
- **ActiveWorkout**: Tracks sets for active workout

## Test plan
- [ ] Complete set from exercise tab (in 1 workout) - auto-assigns
- [ ] Complete set from exercise tab (in 2 workouts) - fills first, then second
- [ ] Complete 5 sets for exercise with 5+5 allocation - first workout shows 5/5, second 0/5
- [ ] Complete 6th set - goes to second workout (1/5)
- [ ] Remove a set - removes from last workout first
- [ ] Start saved workout, complete sets - tracks for that workout
- [ ] Workout cards show accurate per-workout progress
