### PR TITLE
fix: preserve sets in workout optimistic updates

### DIFF
--- a/src/client/features/plan-workouts/hooks.ts
+++ b/src/client/features/plan-workouts/hooks.ts
@@ -120,6 +120,7 @@ export function useCreatePlanWorkout(planId: string) {
                 items: variables.items.map((item, index) => ({
                     planExerciseId: item.planExerciseId,
                     order: index,
+                    sets: item.sets,
                 })),
                 order: nextOrder,
                 createdAt: new Date().toISOString(),
@@ -198,6 +199,7 @@ export function useUpdatePlanWorkout(planId: string) {
                             updates.items = variables.items.map((item, index) => ({
                                 planExerciseId: item.planExerciseId,
                                 order: index,
+                                sets: item.sets,
                             }));
                         }
 


### PR DESCRIPTION
The workout dialog was correctly passing sets per exercise, but the
optimistic update handlers were dropping the sets field when mapping
items. This caused sets to not appear saved until a page refresh.